### PR TITLE
feat: Add GitHub Actions workflows and Semgrep integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Test Annotate Semgrep Action
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: python parse_semgrep.py tests/test_result.json > generated_output.txt
+      - run: diff -u tests/expected_output.txt generated_output.txt
+
+      - name: Run Annotate Semgrep Action with annotations
+        uses: ./
+        with:
+          json_path: tests/test_result.json

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,20 @@
+name: Ruff
+on: [ pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: pipx install ruff
+
+      - name: Get changed Python files
+        id: changed-py-files
+        uses: tj-actions/changed-files@v42
+        with:
+          files: |
+            **/*.py
+
+      - name: Run Ruff
+        if: steps.changed-py-files.outputs.any_changed == 'true'
+        run: ruff check --output-format=github ${{ steps.changed-py-files.outputs.all_changed_files }} --force-exclude

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,35 @@
+name: Semgrep
+on: [ pull_request ]
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Semgrep
+        run: pipx install semgrep
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files_ignore: |
+            **/tests/**
+            **/conftest.py
+
+      - name: Run Semgrep on changed files
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          semgrep scan \
+                  --config auto \
+                  --json \
+                  ${{ steps.changed-files.outputs.all_changed_files }} \
+                  > results.json
+
+      - name: Run Annotate Semgrep Action
+        uses: ./
+        with:
+          json_path: results.json
+          fail_on: "ERROR,WARNING"

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,7 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+.aider*
+.idea
+
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+RUN adduser --disabled-password --gecos "" myuser
+
+USER myuser
+
+COPY parse_semgrep.py /app/parse_semgrep.py
+
+ENTRYPOINT ["python", "/app/parse_semgrep.py"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# annotate-semgrep-action
-GitHub Action for converting Semgrep JSON reports into PR annotations
+[![Build and Test](https://github.com/drew2a/annotate-semgrep-action/actions/workflows/ci.yml/badge.svg)](https://github.com/drew2a/annotate-semgrep-action/actions/workflows/ci.yml)
+
+# Annotate Semgrep Action
+
+This GitHub Action parses Semgrep JSON reports and adds GitHub PR annotations for detected issues.
+
+# What's new
+
+Please refer to the [release page](https://github.com/drew2a/annotate-semgrep-action/releases/latest) for the latest release notes.
+
+# Usage
+
+<!-- start usage -->
+```yaml
+- uses: drew2a/annotate-semgrep-action@v1
+  with:
+    # Path to the JSON Semgrep report
+    # Required
+    json_path: "results.json"
+
+    # Comma-separated list of severity levels that will fail the job (e.g., ERROR,WARNING)
+    # Optional
+    fail_on: ""
+```
+<!-- end usage -->
+
+### Example of usage
+
+```yaml
+- name: Run Semgrep
+  run: semgrep --config=auto --json > results.json
+
+- name: Annotate Semgrep issues
+  uses: drew2a/annotate-semgrep-action@v1
+  with:
+    json_path: "results.json"
+    fail_on: "ERROR,WARNING"
+```
+
+### Example of added annotations
+
+![image](https://github.com/user-attachments/assets/c30aab20-dbb8-48bf-ae06-62f2b2e00bf7)
+
+
+# License
+
+The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,21 @@
+name: "Annotate Semgrep"
+description: "GitHub Action for converting Semgrep JSON reports into PR annotations"
+author: "Andrei Andreev"
+branding:
+  icon: "check"
+  color: "blue"
+inputs:
+  json_path:
+    description: "Path to the JSON Semgrep report"
+    required: true
+    default: "results.json"
+  fail_on:
+    description: "Comma-separated list of severity levels that will fail the job (e.g., ERROR,WARNING)"
+    required: false
+    default: ""
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - ${{ inputs.json_path }}
+    - --fail-on=${{ inputs.fail_on }}

--- a/parse_semgrep.py
+++ b/parse_semgrep.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Parse Semgrep JSON output and create GitHub Actions annotations.
+
+This script reads Semgrep analysis results from a JSON file and converts them
+into GitHub Actions warning annotations. For each issue found by Semgrep,
+it creates an annotation containing the file path, line number, message,
+suggested fix (if available), and references (if available).
+
+Usage:
+    python parse_semgrep.py [input_file] [output_file] [--fail-on SEVERITY,...]
+
+Arguments:
+    input_file          JSON file containing Semgrep results (default: results.json)
+    --fail-on           Comma-separated list of severity levels that will cause the script
+                        to exit with error (e.g., --fail-on ERROR,WARNING)
+
+The script processes all results before exiting, ensuring all issues are reported.
+Exit code 1 indicates that issues with specified severity levels were found.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def parse_args():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input_file', nargs='?', default='results.json',
+                        help='JSON file containing Semgrep results')
+    parser.add_argument('--fail-on', type=str,
+                        help='Comma-separated list of severity levels that will cause failure')
+    return parser.parse_args()
+
+
+def wrap_text(text, width=120):
+    """Wrap the given text at approximately `width` characters without breaking words."""
+    current_line = []
+    current_len = 0
+    for word in text.split():
+        current_line.append(word)
+        current_len += len(word)
+        if current_len > width:
+            yield ' '.join(current_line)
+            current_line = []
+            current_len = 0
+    yield ' '.join(current_line)
+
+
+def main():
+    args = parse_args()
+    # Parse comma-separated fail-on severity levels (if provided) and convert to uppercase.
+    fail_on = set(level.upper() for level in args.fail_on.split(',')) if args.fail_on else set()
+
+    # Load JSON data from the input file.
+    with open(Path(args.input_file), "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    # Exit early if there are no results.
+    if "results" not in data or not data["results"]:
+        sys.exit(0)
+
+    found_severe_issues = False
+    # Accumulate all annotation lines.
+
+    for issue in data["results"]:
+        path = issue.get("path")
+        start_line = issue.get("start", {}).get("line", 1)
+        message = issue.get("extra", {}).get("message", "No message")
+        severity = issue.get("extra", {}).get("severity", "WARNING").upper()
+
+        # Map Semgrep severity to GitHub annotation level.
+        level = {
+            "ERROR": "error",
+            "WARNING": "warning",
+            "INFO": "notice",
+        }.get(severity, "warning")  # default to warning if unknown severity
+
+        fix = issue.get("fix", "")
+        metadata = issue.get("extra", {}).get("metadata", {})
+        references = metadata.get("references", [])
+        confidence = metadata.get("confidence", "Unknown")
+        likelihood = metadata.get("likelihood", "Unknown")
+        impact = metadata.get("impact", "Unknown")
+        source = metadata.get("source", "Unknown")
+
+        # Build the annotation message.
+        annotation_msg = "%0A".join(wrap_text(message))
+        if fix:
+            wrapped_fix = "%0A".join(wrap_text(fix))
+            annotation_msg += f"%0ASuggested fix: {wrapped_fix}"
+
+        annotation_msg += "%0A%0AMetadata:"
+        annotation_msg += f"%0A- Confidence: {confidence}"
+        annotation_msg += f"%0A- Likelihood: {likelihood}"
+        annotation_msg += f"%0A- Impact: {impact}"
+        annotation_msg += f"%0A- Source: {source}"
+
+        if references:
+            ref_list = "%0A".join(f'- {ref}' for ref in references)
+            annotation_msg += f"%0A%0AReferences:%0A{ref_list}"
+
+        # Form the GitHub Actions annotation command.
+        print(f"::{level} file={path},line={start_line}::{annotation_msg}")
+        if severity in fail_on:
+            found_severe_issues = True
+
+    if found_severe_issues:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/expected_output.txt
+++ b/tests/expected_output.txt
@@ -1,0 +1,1 @@
+::warning file=parse_semgrep.py,line=1::Test annotation%0A%0AMetadata:%0A- Confidence: LOW%0A- Likelihood: LOW%0A- Impact: HIGH%0A- Source: https://semgrep.dev/r/python.lang.security.audit.formatted-sql-query.formatted-sql-query%0A%0AReferences:%0A- https://stackoverflow.com/questions/775296/mysql-parameterized-queries

--- a/tests/test_result.json
+++ b/tests/test_result.json
@@ -1,0 +1,74 @@
+{
+  "version": "1.101.0",
+  "results": [
+    {
+      "check_id": "python.lang.security.audit.formatted-sql-query.formatted-sql-query",
+      "path": "parse_semgrep.py",
+      "start": {
+        "line": 1,
+        "col": 1,
+        "offset": 1
+      },
+      "end": {
+        "line": 1,
+        "col": 2,
+        "offset": 1
+      },
+      "extra": {
+        "message": "Test annotation",
+        "metadata": {
+          "owasp": [
+            "A01:2017 - Injection",
+            "A03:2021 - Injection"
+          ],
+          "cwe": [
+            "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+          ],
+          "references": [
+            "https://stackoverflow.com/questions/775296/mysql-parameterized-queries"
+          ],
+          "category": "security",
+          "technology": [
+            "python"
+          ],
+          "cwe2022-top25": true,
+          "cwe2021-top25": true,
+          "subcategory": [
+            "audit"
+          ],
+          "likelihood": "LOW",
+          "impact": "HIGH",
+          "confidence": "LOW",
+          "license": "Semgrep Rules License v1.0. For more details, visit semgrep.dev/legal/rules-license",
+          "vulnerability_class": [
+            "SQL Injection"
+          ],
+          "source": "https://semgrep.dev/r/python.lang.security.audit.formatted-sql-query.formatted-sql-query",
+          "shortlink": "https://sg.run/EkWw",
+          "semgrep.dev": {
+            "rule": {
+              "origin": "community",
+              "r_id": 9637,
+              "rule_id": "3qUP9k",
+              "rv_id": 946343,
+              "url": "https://semgrep.dev/playground/r/e1T98KK/python.lang.security.audit.formatted-sql-query.formatted-sql-query",
+              "version_id": "e1T98KK"
+            }
+          }
+        },
+        "severity": "WARNING",
+        "fingerprint": "requires login",
+        "lines": "requires login",
+        "validation_state": "NO_VALIDATOR",
+        "engine_kind": "OSS"
+      }
+    }
+  ],
+  "errors": [],
+  "paths": {
+    "scanned": [
+      "parse_semgrep.py"
+    ]
+  },
+  "skipped_rules": []
+}


### PR DESCRIPTION
Introduced three new GitHub Actions workflows for code quality checks. The first workflow runs a custom script to parse Semgrep results and generate annotations. The second workflow uses Ruff to lint Python files that have been modified in a pull request. The third workflow installs and runs Semgrep on changed files, excluding test files and configuration scripts.

Also added a Dockerfile for running the Semgrep parsing script in an isolated environment, along with the script itself which reads Semgrep analysis results from a JSON file and converts them into GitHub Actions warning annotations.

Updated .gitignore to ignore IDE-specific directories and temporary files generated by the build process.

Created action.yml defining inputs, outputs, and execution environment for the new GitHub Action that annotates PRs with Semgrep findings.
